### PR TITLE
allow password and tokens

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = confluence.md
-version = 0.2.1
+version = 0.2.2
 author = Szymon Nieradka
 description = Markdown to Confluence - upload any .md files to your Confluence cloud page
 long_description = file: README.md

--- a/src/md2cf/main.py
+++ b/src/md2cf/main.py
@@ -20,8 +20,9 @@ def register_action(function):
     return wrapper
 
 def init_confluence(args):
-    return ConfluenceMD(username=args.user, token=args.token, md_file=args.file.name,
-            url=args.url, add_meta=args.add_meta, add_info_panel=args.add_info,
+    return ConfluenceMD(username=args.user, token=args.token,
+            password=args.password, md_file=args.file.name, url=args.url,
+            add_meta=args.add_meta, add_info_panel=args.add_info,
             add_label=args.add_label)
 
 @register_action
@@ -79,8 +80,12 @@ Actions:
     auth_args = parser.add_argument_group('required auth parameters')
     auth_args.add_argument("-u", "--user", action="store", required=True,
             help="Atlassian username/email")
-    auth_args.add_argument("-t", "--token", action="store", required=True,
+
+    secret_args = auth_args.add_mutually_exclusive_group(required=True)
+    secret_args.add_argument("-t", "--token", action="store", required=True,
             help="Atlassian API token")
+    secret_args.add_argument("-p", "--password", action="store", required=True,
+            help="Atlassian password")
     auth_args.add_argument("-l", "--url", action="store", required=False,
             help="Atlassian instance URL")
 

--- a/src/md2cf/utils/confluencemd.py
+++ b/src/md2cf/utils/confluencemd.py
@@ -16,8 +16,9 @@ class ConfluenceMD(atlassian.Confluence):
     def __init__(
         self,
         username: str,
-        token: str,
         md_file: str,
+        token: str = '',
+        password: str = '',
         url: str = None,
         add_meta: bool = False,
         add_info_panel: bool = False,
@@ -25,6 +26,7 @@ class ConfluenceMD(atlassian.Confluence):
     ) -> None:
         self.username = username
         self.token = token
+        self.password = password
         self.md_file = md_file
         self.url = url
         self.add_meta = add_meta
@@ -35,7 +37,15 @@ class ConfluenceMD(atlassian.Confluence):
             self.init()
 
     def init(self):
-        super().__init__(url=self.url, username=self.username, password=self.token)
+        kwargs = {
+            'url': self.url,
+            'username': self.username
+        }
+        if self.password:
+            kwargs['password'] = self.password
+        if self.token:
+            kwargs['token'] = self.token
+        super().__init__(**kwargs)
 
     def rewrite_images(
         self, page_id: str, html: str, images: List[Tuple[str, str]]


### PR DESCRIPTION
The `token` on the command line was getting assigned to `password`.  While this worked for Confluence in the cloud, it didn't for local instances.  Rather, I could provide my instance password, instead of token and it worked.  The `Confluence` object already allows specification of both, so it was added.  With the change I was able to test with a personal access token and my password successfully.  However, I don't have access to a cloud version to ensure there wasn't a regression...

