### PR TITLE
modified info panel text for grammar and style + spelling

### DIFF
--- a/src/md2cf/utils/confluencemd.py
+++ b/src/md2cf/utils/confluencemd.py
@@ -258,7 +258,7 @@ class ConfluenceMD(atlassian.Confluence):
             self, page_id: str, images: List[Tuple[str, str]]
     ) -> None:
         """Replaces <img> html tags with Confluence specific <ac:image> and uploads
-           images as attachements"""
+           images as attachments"""
         for (_alt, path) in images:
             rel_path = os.path.join(self.md_file_dir, path)
             if not os.path.isfile(rel_path):
@@ -306,7 +306,7 @@ class ConfluenceMD(atlassian.Confluence):
 
 
     def __add_label_to_page(self, page_id: str) -> None:
-        """Selfdescriptive"""
+        """Self descriptive"""
         if not self.add_label:
             return
         self.set_page_label(page_id, self.add_label)

--- a/src/md2cf/utils/md2html.py
+++ b/src/md2cf/utils/md2html.py
@@ -64,8 +64,8 @@ def __get_info_panel(md_file: str) -> str:
     if --add_info is added
     """
     return f"""
-        <p><strong>Automatic content</strong> This page was generated automatically from
-        <code>{md_file}</code> file.Do not edit it on Confluence.</p><hr />
+    <p><strong>Automatic content</strong> - Do not edit this page in Confluence.
+    Page automatically generated from: <code>{md_file}</code></p><hr />
     """
 
 def __get_images_from_file(md: str) -> List:
@@ -82,7 +82,7 @@ def __rewrite_images(html: str,
                      images: List[Tuple[str, str]]
                      ) -> str:
     """Replaces <img> html tags with Confluence specific <ac:image> and uploads
-        images as attachements"""
+        images as attachments"""
     for (alt, path) in images:
         rel_path = os.path.join(md_file_dir, path)
         if not os.path.isfile(rel_path):


### PR DESCRIPTION
Slight modification of the info panel text as ours comes out with a couple of spaces on the second line, a missing space before the second sentence and somewhat weird grammar.
Minimal auto spell check corrections in 3 other places.

![image](https://github.com/user-attachments/assets/28b625de-52b9-4fa4-9610-374b1164aa71)