### PR TITLE
update image pattern regex to include nested parentheses

### DIFF
--- a/src/md2cf/utils/md2html.py
+++ b/src/md2cf/utils/md2html.py
@@ -9,7 +9,7 @@ import markdown2
 from .log import logger
 
 CF_URL = re.compile(r"(?P<host>https?://[^/]+)/.*/(?P<page_id>\d+)")
-IMAGE_PATTERN = re.compile(r"!\[(?P<alt>[^\]]*)\]\((?P<path>.+)\)")
+IMAGE_PATTERN = re.compile(r"!\[(?P<alt>[^\]]*)\]\((?P<path>[^:]+)\)")
 
 
 def md_to_html(md_file: str,

--- a/src/md2cf/utils/md2html.py
+++ b/src/md2cf/utils/md2html.py
@@ -9,7 +9,7 @@ import markdown2
 from .log import logger
 
 CF_URL = re.compile(r"(?P<host>https?://[^/]+)/.*/(?P<page_id>\d+)")
-IMAGE_PATTERN = re.compile(r"\!\[(?P<alt>.*)\]\((?P<path>[^:)]+)\)")
+IMAGE_PATTERN = re.compile(r"!\[(?P<alt>[^\]]*)\]\((?P<path>.+)\)")
 
 
 def md_to_html(md_file: str,


### PR DESCRIPTION
Currently the regex will not match the full image path for an image that includes parentheses.

Example: `![Logo](.attachments/Logo(1).png)` will match Logo(1, causing the process to fail.

New Output: `![Logo](.attachments/Logo(1).png)` will match Logo(1).png, allowing the process to succeed.